### PR TITLE
Patched so that the gcloud_config_helper library works normally on Windows.

### DIFF
--- a/gcloud_config_helper/gcloud_config_helper.py
+++ b/gcloud_config_helper/gcloud_config_helper.py
@@ -42,9 +42,10 @@ class GCloudCredentials(CredentialsWithQuotaProject):
         executes the gcloud config config-helper for the configuration with `self._name` and stores the resulting
         dictionary in `self.config`.
         """
+        gcloud_absolute_path = shutil.which('gcloud')
         process = subprocess.Popen(
             [
-                "gcloud",
+                gcloud_absolute_path,
                 "config",
                 "config-helper",
                 "--configuration",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.2.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/binxio/python-gcloud-config-helper',
-    version='0.2.2',
+    version='0.2.3',
     zip_safe=False,
 )


### PR DESCRIPTION
The execution path of gcloud, which is executed when obtaining authentication from gcloud, is found through shutil and then executed.

Detailed error history was reported in issue #2.

I need to upload a new version to PyPI urgently after this patch is applied.